### PR TITLE
[CBP-42405] chore: Update latest image version in action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -32,7 +32,7 @@ runs:
   steps:
     - id: invoke-gitlab-action
       name: invoke-gitlab-action
-      uses: docker://public.ecr.aws/l7o7z1g8/actions/gitlab-actions:main-3d76192b241d7a284a41fbc0f4fbe44e7033566d
+      uses: docker://public.ecr.aws/l7o7z1g8/actions/gitlab-actions:main-ec353c869fd2aceee96d550726f196b27609e4b3
       shell: sh
       env: 
         RUN_ID: ${{ cloudbees.run_id }}


### PR DESCRIPTION
Update docker image tag to latest version from `action_artifacts.json`.